### PR TITLE
Update mapping to have configurable app label

### DIFF
--- a/statsd_mapping.yml
+++ b/statsd_mapping.yml
@@ -1,8 +1,10 @@
 mappings:
-- match: "datahub.*.calendar-invite-ingest.*.*"
+- match: "*.*.calendar-invite-ingest.*.*"
   name: "calendar_invite_ingest_total"
   labels:
-    source: "$1"
-    result: "$2"
-    domain: "$3"
+    app: "$1"
+    source: "$2"
+    result: "$3"
+    domain: "$4"
     job: "calendar-invite-ingest"
+


### PR DESCRIPTION
This is so that we can point `datahub-api-dev` as well as `datahub-api-staging` to the same `prometheus-exporter` instance.